### PR TITLE
Return se in sematrix instead of exp(coef)

### DIFF
--- a/R/ds.coxph.SLMA.R
+++ b/R/ds.coxph.SLMA.R
@@ -217,7 +217,7 @@ ds.coxph.SLMA <- function(formula = NULL,
        for (k in 1:numstudies)
        {
            betamatrix[,k] <- output[[k]]$coefficients[,1]
-           sematrix[,k]   <- output[[k]]$coefficients[,2]
+           sematrix[,k]   <- output[[k]]$coefficients[,3]
        }
 	   
        # create a list to store all RMA metafor values


### PR DESCRIPTION
It seems that the `sematrix` returned when calling `ds.coxph.SLMA` with `combine_with_metafor = TRUE` is returning the exp(coef) column, and not the se(coef) column. This pull request should resolve that.